### PR TITLE
Update ldap.R

### DIFF
--- a/R/ldap.R
+++ b/R/ldap.R
@@ -66,6 +66,6 @@ ldap <- R6::R6Class("ldap",
 ldap_unbind <- function(
   private
 ){
-  ldap_unbind(private$handle)
+  ldapr_unbind(private$handle)
 }
 


### PR DESCRIPTION
changing the ldap_unbind  that creates a recursive call to ldap_unbind function, to ldapr_unbind. ldapr_unbind function exists in RcppExports and it .Calls the ldapr_unbind.cpp function.

I believe that it solves the issue. 

Unfortunately, it also crashes R. 